### PR TITLE
Miscelaneos fixes.

### DIFF
--- a/include/phd/text/c_string_view.hpp
+++ b/include/phd/text/c_string_view.hpp
@@ -20,7 +20,7 @@ namespace phd {
 		constexpr inline c_string_view operator"" _csv(const char* str_, size_t len_) noexcept {
 			return c_string_view(str_, len_);
 		}
-#if defined(__cpp_char_8t)
+#if defined(__cpp_char8_t)
 		constexpr inline u8c_string_view operator"" _csv(const char8_t* str_, size_t len_) noexcept {
 			return u8c_string_view(str_, len_);
 		}

--- a/include/phd/text/utf8.hpp
+++ b/include/phd/text/utf8.hpp
@@ -195,19 +195,18 @@ namespace phd {
 					}
 				}
 
-				code_point __decoded;
-				switch (length) {
-				case 2:
-					__decoded = __unicode_detail::__decode(b[0], b[1]);
-					break;
-				case 3:
-					__decoded = __unicode_detail::__decode(b[0], b[1], b[2]);
-					break;
-				case 4:
-				default:
-					__decoded = __unicode_detail::__decode(b[0], b[1], b[2], b[3]);
-					break;
-				}
+				code_point __decoded = [&length, &b]() { // invoked inplace
+					switch (length) {
+					case 2:
+						return __unicode_detail::__decode(b[0], b[1]);
+					case 3:
+						return __unicode_detail::__decode(b[0], b[1], b[2]);
+					case 4:
+						[[fallthrough]];
+					default:
+						return __unicode_detail::__decode(b[0], b[1], b[2], b[3]);
+					}
+				}();
 
 				if constexpr (__call_error_handler) {
 					if constexpr (!__overlong_allowed) {


### PR DESCRIPTION
The code as-is was not compiling in c++20 on clang-9, these little tweaks should fix those issues.

I also based my changes on the ``master^`` instead of ``master`` as the submodule where some part of the code went is not available.